### PR TITLE
Added custom 2525C type functionality.

### DIFF
--- a/src/atakcots/CotConfig.py
+++ b/src/atakcots/CotConfig.py
@@ -17,6 +17,8 @@ class CotConfig(BaseModel):
     longitude: float = Field(description="Longitude along the WGS 84 ellipsoid in degrees")
     altitude: float = Field(default=0.0, description="Height above the WGS 84 ellipsoid in meters")
 
+    type: str = Field(default="a-U-G", description="The MIL-STD-2525C symbol of the COT")
+
     stale_duration: int = Field(default=600, description="Number of seconds before cot message becomes stale")
 
     callsign: str = Field(default="default_callsign", description="Callsign of event described by cot")

--- a/src/atakcots/message.py
+++ b/src/atakcots/message.py
@@ -46,7 +46,7 @@ def compose_message(
     event.set("uid", cot_config.uid)
 
     # methodology data
-    event.set("type", f"a-{cot_config.attitude}-{cot_config.dimension}")
+    event.set("type", cot_config.type)
     event.set("how", cot_config.how)
     
     # time data


### PR DESCRIPTION
Default type is unmarked, unknown ground 2525C. To change, must initialize type in CotConfig object along with other desired properties.